### PR TITLE
Add logo background colors and tidy up some employers

### DIFF
--- a/public/employers/README.md
+++ b/public/employers/README.md
@@ -13,7 +13,7 @@ We recommend you make a copy of `sample.yml` and adjust it to fit your needs. Th
 - `shortName`: An optional shortened version of the company's name.
 - `ticker`: The stock ticker symbol for the company, if they are publicly traded.
 - `wiki`: The subpath for the company's English Wikipedia page, if any. Spaces will be converted to underscores.
-- `image`: An optional name of a logo, in SVG format, in the 'public/images/employers' directory.
+- `image`: An optional name of a logo, in SVG format, in the 'public/images/employers' directory. A background color can also be specified by appending a hex code to the end, e.g. `image.svg#abc123`.
 - `officialWebsite`: An official company webpage describing the company and its corporate mission, culture, and so on.
 - `industries`: A list of industries of which the company is considered to be a part. Please see the `EmployerIndustry.ts` file for possible values here. (If you think one is missing, please request to add it.)
 - `location`: Where the company is originally based.

--- a/public/employers/README.md
+++ b/public/employers/README.md
@@ -28,7 +28,12 @@ We recommend you make a copy of `sample.yml` and adjust it to fit your needs. Th
 - `summary`: A general summary about the company. Should be 100-350 characters and avoid too many specific details. [Markdown](https://www.markdownguide.org/basic-syntax/) is supported here.
 - `citations`: A list of claims about the employer. Each one should indicate a number of things:
 	- `summary`: A textual summary of the claim. Should mention all specifics of the claim, and include dates when necessary. Generally, should be written in the past-passive tense, such as "Contoso has started ...", or "Contoso employees have been ...". Events that happened but are not ongoing can be written entirely in past tense, such as "Contoso issued a statement saying ...". [Markdown](https://www.markdownguide.org/basic-syntax/) is supported here.
-	- `positivity`: A value from -2 to +2 that indicates how positive the news is. -2 would be severely negative; 0 would be neutral; +2 would be incredibly positive.
+	- `positivity`: A value from 2 to -2 that indicates how positive the news is.
+		- 2: Highly positive. For example, going above and beyond mandated protocols to ensure employees are paid, executives paying out of pocket to ensure jobs or livelihoods, or redirecting capital or resources away from revenue efforts toward curbing COVID-19's spread and effect.
+		- 1: Positive. For example, not cutting employee salaries, following government mandates, or stepping up cleaning protocols.
+		- 0: Neutral. For example, cutting both executive and worker salaries, or taking actions against COVID-19 but which are not related to employee happiness or job security. Announcements which have also not yet come to fruition should also be marked as neutral.
+		- -1: Negative. For example, cutting employee salaries or furloughing without benefits.
+		- -2: Highly negative. For example, actively showing neglect for employee safety, or paying out executive bonuses while also laying off employees.
 	- `type`: Indicates that the **original** fact source is a published statement from an employee, whether they are a current, former, or anonymous source.
 	- `sources`: A list of sources for the claim.
 		- `source`: The website name or description.

--- a/public/employers/airbnb.yml
+++ b/public/employers/airbnb.yml
@@ -1,7 +1,7 @@
 name: Airbnb, Inc.
 shortName: Airbnb
 wiki: Airbnb
-image: airbnb.svg
+image: airbnb.svg#fd5c63
 officialWebsite: https://news.airbnb.com/about-us/
 industries:
   - lodging

--- a/public/employers/mcdonalds.yml
+++ b/public/employers/mcdonalds.yml
@@ -15,7 +15,7 @@ employeesBefore:
   type: approximately
   upperBound: 210000
   year: 2018
-summary: McDonald's has generally shown goodwill during the COVID-19 pandemic, closing public areas but continuing drive-thru, and providing providing free lunches and free delivery.
+summary: McDonald's has generally shown goodwill during the COVID-19 pandemic, closing public areas but continuing drive-thru, and providing free lunches and free delivery.
 citations:
   - summary: McDonald's has been considered an essential service but has closed seating areas and play places; it has begun operating in a no-contact manner, allowing drive-thru and curbside pickup.
     positivity: 1

--- a/public/employers/snc-lavalin.yml
+++ b/public/employers/snc-lavalin.yml
@@ -22,7 +22,7 @@ employeesBefore:
 summary: While SNC-Lavalin executives have taken pay cuts of 20%, they are forcing all workers to take pay cuts of at least 10% (up to 20% if they don't opt out), while still showing strong indicators that the company has millions in spare capital.
 citations:
   - summary: SNC has introduced a motion within the company which cuts all workers' pay by at least 10% for three months. They also requested that employees agree to elevate this cut to 20%, but allowed them to opt out by notifying their manager.
-    positivity: -2
+    positivity: -1
     type: publication
     sources:
       - source: The Globe and Mail

--- a/public/employers/starbucks.yml
+++ b/public/employers/starbucks.yml
@@ -1,7 +1,7 @@
 name: Starbucks
 ticker: SBUX
 wiki: Starbucks
-image: starbucks.svg
+image: starbucks.svg#00643c
 officialWebsite: https://www.starbucks.com/about-us/company-information
 industries:
   - coffeeShop

--- a/public/employers/target.yml
+++ b/public/employers/target.yml
@@ -4,7 +4,7 @@ aliases:
   - TargetExpress
 ticker: TGT
 wiki: Target Corporation
-image: target.svg
+image: target.svg#e50024
 officialWebsite: https://corporate.target.com/
 industries:
   - retail

--- a/public/employers/ucirvine.yml
+++ b/public/employers/ucirvine.yml
@@ -19,7 +19,7 @@ employeesBefore:
   yearQuarter: Q4
 summary: UCI has cancelled graduation ceremonies amidst the outbreak early on, switched all classes to online, and have made enormous effort to fight COVID-19.
 citations:
-  - summary: UCI have cancelled graduation ceremonies, but will still graduate.
+  - summary: UCI has cancelled graduation ceremonies, but will still allow students to graduate.
     positivity: 1
     type: publication
     sources:
@@ -33,14 +33,14 @@ citations:
       - source: Los Angeles Times
         link: https://www.latimes.com/socal/daily-pilot/news/story/2020-04-07/departments-across-uc-irvine-design-build-face-shields-for-medical-staff-in-orange
         date: 2020-04-07T15:53:00-07:00
-  - summary: UCI has switched to online classes.
+  - summary: UCI has switched exclusively to online classes.
     positivity: 1
     type: statement
     sources:
       - source: The Mercury News
         link: https://www.mercurynews.com/2020/03/18/give-us-a-tuition-break-say-california-students-forced-into-online-university-classes/
         date: 2020-03-18T05:54:19-07:00
-  - summary: Students may not get full refund for their tuition due to less facetime with their professors or struggle with online only classes.
+  - summary: Students, who have requested refunds due to less facetime with their professors or struggling with online-only classes, may not get full refund for their tuition.
     positivity: -1
     type: statement
     sources:

--- a/public/employers/ucirvine.yml
+++ b/public/employers/ucirvine.yml
@@ -2,7 +2,7 @@ name: UC Irvine
 aliases:
   - UCI
 wiki: University of California, Irvine
-image: ucirvine.svg
+image: ucirvine.svg#1d76ae
 officialWebsite: https://uci.edu/
 industries:
   - education

--- a/src/common/EmployerRecordBase.ts
+++ b/src/common/EmployerRecordBase.ts
@@ -4,6 +4,8 @@ import { EmployerLocation } from "./EmployerLocation";
 import { EmployerRating } from "./EmployerRating";
 
 export abstract class EmployerRecordBase {
+	public static readonly IMAGE_REGEX: RegExp = /^([a-z0-9-]+\.(?:png|svg|jpe?g))(#[a-f0-9]{6})?$/;
+
 	public aliases?: string[];
 
 	public employeesBefore?: EmployerEmployeeProfile;

--- a/src/web/views/EmployerDetailsHeader/EmployerDetailsHeader.scss
+++ b/src/web/views/EmployerDetailsHeader/EmployerDetailsHeader.scss
@@ -6,7 +6,6 @@ $icon-size: 32px;
 $padding-interior: 12px;
 
 .EmployerDetailsHeader__Icon {
-	background: $background;
 	border-radius: ($icon-size / 2) ($icon-size / 2);
 	height: $icon-size;
 	margin-right: ($padding-interior / 2);

--- a/src/web/views/EmployerDetailsHeader/EmployerDetailsHeader.tsx
+++ b/src/web/views/EmployerDetailsHeader/EmployerDetailsHeader.tsx
@@ -5,8 +5,7 @@ import { RouteProps } from "react-router-dom";
 import { DesignHelpers } from "../../../common/DesignHelpers";
 import { EmployerEmployeeProfile } from "../../../common/EmployerEmployeeProfile";
 import { EmployerLocation } from "../../../common/EmployerLocation";
-import { EmployerRating } from "../../../common/EmployerRating";
-import { EmployerRecord } from "../../../common/EmployerRecord";
+import { EmployerRecordBase } from "../../../common/EmployerRecordBase";
 import { EmployerRecordMetadata } from "../../../common/EmployerRecordMetadata";
 import { format, LocalizedStrings } from "../../../common/LocalizedStrings";
 import { WikipediaHelpers } from "../../../common/WikipediaHelpers";
@@ -163,10 +162,19 @@ const EmployerDetailsHeader: React.FC<Props> = (props: Props): React.ReactElemen
 			? <a onClick={onClickEmployerName} title={employer.name !== displayName ? employer.name : ""}>{displayName}</a>
 			: <>{displayName}</>;
 
+	const logoImageRegex: RegExpExecArray | null =
+		employer.image ? EmployerRecordBase.IMAGE_REGEX.exec(employer.image) : null;
+
 	return (
 		<>
 			<div className={`EmployerDetailsHeader__Title ${useShortText ? "" : "EmployerDetailsHeader__Title--noShort"}`}>
-				{employer.image && <img className="EmployerDetailsHeader__Icon" src={`/images/employers/${employer.image}`} />}
+				{logoImageRegex && (
+					<img
+						className="EmployerDetailsHeader__Icon"
+						src={`/images/employers/${logoImageRegex[1]}`}
+						style={{ background: logoImageRegex[2] || "#fff" }}
+					/>
+				)}
 				<h2>
 					{employerNameComponent}
 					{!useShortText && getTickerComponent(employer, strings)}

--- a/src/web/views/EmployerDetailsHeader/__snapshots__/EmployerDetailsHeader.test.tsx.snap
+++ b/src/web/views/EmployerDetailsHeader/__snapshots__/EmployerDetailsHeader.test.tsx.snap
@@ -8,6 +8,11 @@ Array [
     <img
       className="EmployerDetailsHeader__Icon"
       src="/images/employers/consoto.svg"
+      style={
+        Object {
+          "background": "#fff",
+        }
+      }
     />
     <h2>
       <a


### PR DESCRIPTION
- Add support for a background color behind employer logos
- Clean up some positivity ratings and wordings
- Fix `fail()` not halting the employer record tests