### PR TITLE
Limit the number of employer items loaded at a time

### DIFF
--- a/public/strings/en-us.yml
+++ b/public/strings/en-us.yml
@@ -365,6 +365,7 @@ linkTypes:
   parent: Parent company
   related: Related
 loading: Loading...
+loadMore: Load {count} more
 more: "{number} more"
 noResults: No results.
 noSources: Word of mouth; no citation

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -4,8 +4,7 @@ import { Route, Switch } from "react-router-dom";
 
 import { getEmployersList } from "./state/ducks/employers/actions";
 import AboutPage from "./views/AboutPage/AboutPage";
-import EmployerListPage from "./views/EmployerListPage/EmployerListPage";
-import EmployerPage from "./views/EmployerPage/EmployerPage";
+import EmployerRoute from "./views/EmployerRoute/EmployerRoute";
 import FooterMenu from "./views/HeaderFooter/FooterMenu";
 import HeaderMenu from "./views/HeaderFooter/HeaderMenu";
 import HomePage from "./views/HomePage/HomePage";
@@ -28,8 +27,7 @@ const App: React.FC = (): React.ReactElement => {
 			<HeaderMenu />
 			<Switch>
 				<Route exact={true} path="/" component={HomePage} />
-				<Route exact={true} path="/employers" component={EmployerListPage} />
-				<Route exact={true} path="/employers/:id" component={EmployerPage} />
+				<Route path="/employers/:id?" component={EmployerRoute} />
 				<Route path="/about" component={AboutPage} />
 			</Switch>
 			<FooterMenu />

--- a/src/web/views/EmployerCitation/EmployerCitation.tsx
+++ b/src/web/views/EmployerCitation/EmployerCitation.tsx
@@ -34,8 +34,8 @@ const EmployerCitation: React.FC<Props> = (props: Props): React.ReactElement => 
 			}
 
 			return (
-				<span className="EmployerCitation__ReferenceContainer">
-					<a key={i} href={s.link} rel="noopener noreferrer" target="_blank" title={title}>
+				<span key={i} className="EmployerCitation__ReferenceContainer">
+					<a href={s.link} rel="noopener noreferrer" target="_blank" title={title}>
 						{s.source}
 					</a>
 				</span>

--- a/src/web/views/EmployerList/EmployerList.scss
+++ b/src/web/views/EmployerList/EmployerList.scss
@@ -8,64 +8,51 @@ $close-button-size-small: 32px;
 $body-2column-width: ($card-min-width * 2 + 40px);
 $body-3column-width: ($card-min-width * 3 + 120px);
 
-div.EmployerList__Container--Loading, div.EmployerList__Container--NoResults {
+.EmployerList__Container--Loading, .EmployerList__Container--NoResults {
 	font: 400 20px 'Baloo Chettan 2';
 	margin: 16px auto;
 	text-align: center;
 }
 
-div.EmployerList__Container {
+.EmployerList__LoadMore {
+	background: $background;
+	border: 1px solid $header;
+	border-radius: 32px;
+	color: $header;
+	cursor: pointer;
+	display: block;
+	font-family: inherit;
+	font-size: 24px;
+	height: 64px;
+	margin: 30px auto;
+	outline: none;
+	padding: 16px 48px;
+
+	&:hover {
+		background: $header;
+		color: $background;
+	}
+}
+
+.EmployerList__Grid {
 	display: grid;
 	grid-auto-rows: max-content;
 	grid-gap: 16px;
 	grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-div.EmployerList__Item {
+.EmployerList__Item {
 	height: 100%;
 }
 
-button.EmployerList__CloseModal {
-	background: $background;
-	border: 0;
-	border-radius: ($close-button-size / 2);
-	box-shadow: 0 2px 6px $box-shadow-color;
-	cursor: pointer;
-	position: fixed;
-	height: $close-button-size;
-	outline: none;
-	pointer-events: initial;
-	right: ($page-padding / 2);
-	top: ($page-padding / 2);
-	width: $close-button-size;
-	z-index: 21;
-
-	i {
-		font-size: 36px;
-		margin-top: 2px;
-	}
-}
-
 @media (max-width: $body-2column-width) {
-	div.EmployerList__Container {
+	.EmployerList__Grid {
 		grid-template-columns: repeat(1, minmax(0, 1fr));
-	}
-
-	button.EmployerList__CloseModal {
-		height: $close-button-size-small;
-		right: ($page-padding-narrow / 2);
-		top: ($page-padding-narrow / 2);
-		width: $close-button-size-small;
-
-		i {
-			font-size: 24px;
-			margin-left: -2px;
-		}
 	}
 }
 
 @media (max-width: $body-3column-width) and (min-width: $body-2column-width) {
-	div.EmployerList__Container {
+	.EmployerList__Grid {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 }

--- a/src/web/views/EmployerList/EmployerList.test.tsx
+++ b/src/web/views/EmployerList/EmployerList.test.tsx
@@ -14,7 +14,7 @@ import { AppState } from "../../state/AppState";
 import configureStore from "../../state/configureStore";
 
 import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
-import { EmployerRouteContext, EmployerRouteContextData } from "../EmployerRoute/EmployerRouteContext";
+import { EmployerRouteContext, EmployerRouteContextData, DefaultContextData } from "../EmployerRoute/EmployerRouteContext";
 
 import EmployerList from "./EmployerList";
 
@@ -37,16 +37,11 @@ describe("<EmployerList />", () => {
 	test("renders without exploding", () => {
 		const store: Store<AppState, AnyAction> = createConfigStore();
 
-		const contextValue: EmployerRouteContextData = {
-			searchFilters: new EmployerListSearchFilter(),
-			setSearchFilters: jest.fn(),
-		};
-
 		const renderedValue: ReactTestRendererJSON | null =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerRouteContext.Provider value={contextValue}>
+						<EmployerRouteContext.Provider value={DefaultContextData}>
 							<EmployerList />
 						</EmployerRouteContext.Provider>
 					</BrowserRouter>
@@ -78,8 +73,8 @@ describe("<EmployerList />", () => {
 		filter.text = "NORESULTSPLEASE";
 
 		const contextValue: EmployerRouteContextData = {
+			...DefaultContextData,
 			searchFilters: filter,
-			setSearchFilters: jest.fn(),
 		};
 
 		const renderedValue: ReactTestRendererJSON | null =
@@ -128,8 +123,8 @@ describe("<EmployerList />", () => {
 		filter.text = "TA";
 
 		const contextValue: EmployerRouteContextData = {
+			...DefaultContextData,
 			searchFilters: filter,
-			setSearchFilters: jest.fn(),
 		};
 
 		const renderedValue: ReactTestRendererJSON | null =

--- a/src/web/views/EmployerList/EmployerList.test.tsx
+++ b/src/web/views/EmployerList/EmployerList.test.tsx
@@ -14,6 +14,7 @@ import { AppState } from "../../state/AppState";
 import configureStore from "../../state/configureStore";
 
 import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
+import { EmployerRouteContext, EmployerRouteContextData } from "../EmployerRoute/EmployerRouteContext";
 
 import EmployerList from "./EmployerList";
 
@@ -36,13 +37,18 @@ describe("<EmployerList />", () => {
 	test("renders without exploding", () => {
 		const store: Store<AppState, AnyAction> = createConfigStore();
 
+		const contextValue: EmployerRouteContextData = {
+			searchFilters: new EmployerListSearchFilter(),
+			setSearchFilters: jest.fn(),
+		};
+
 		const renderedValue: ReactTestRendererJSON | null =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerList
-							searchFilter={new EmployerListSearchFilter()}
-						/>
+						<EmployerRouteContext.Provider value={contextValue}>
+							<EmployerList />
+						</EmployerRouteContext.Provider>
 					</BrowserRouter>
 				</Provider>,
 			).toJSON();
@@ -71,13 +77,18 @@ describe("<EmployerList />", () => {
 
 		filter.text = "NORESULTSPLEASE";
 
+		const contextValue: EmployerRouteContextData = {
+			searchFilters: filter,
+			setSearchFilters: jest.fn(),
+		};
+
 		const renderedValue: ReactTestRendererJSON | null =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerList
-							searchFilter={filter}
-						/>
+						<EmployerRouteContext.Provider value={contextValue}>
+							<EmployerList />
+						</EmployerRouteContext.Provider>
 					</BrowserRouter>
 				</Provider>,
 			).toJSON();
@@ -116,13 +127,18 @@ describe("<EmployerList />", () => {
 
 		filter.text = "TA";
 
+		const contextValue: EmployerRouteContextData = {
+			searchFilters: filter,
+			setSearchFilters: jest.fn(),
+		};
+
 		const renderedValue: ReactTestRendererJSON | null =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerList
-							searchFilter={filter}
-						/>
+						<EmployerRouteContext.Provider value={contextValue}>
+							<EmployerList />
+						</EmployerRouteContext.Provider>
 					</BrowserRouter>
 				</Provider>,
 			).toJSON();

--- a/src/web/views/EmployerList/EmployerList.tsx
+++ b/src/web/views/EmployerList/EmployerList.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 
 import { EmployerRecordMetadata } from "../../../common/EmployerRecordMetadata";
@@ -22,7 +22,13 @@ const EmployerList: React.FC = (): React.ReactElement => {
 
 	const listContext: EmployerRouteContextData = useContext(EmployerRouteContext);
 
-	const [ visibleItemCount, setVisibleItemCount ] = useState(loadMoreCount);
+	const [ listChunksLoaded, setListChunksLoaded ] = useState(listContext.listChunksLoaded);
+
+	useEffect(
+		(): void => {
+			listContext.setListChunksLoaded(listChunksLoaded);
+		},
+		[ listChunksLoaded ]);
 
 	if (!employersList) {
 		return (
@@ -52,6 +58,8 @@ const EmployerList: React.FC = (): React.ReactElement => {
 		);
 	}
 
+	const visibleItemCount: number = listChunksLoaded * loadMoreCount;
+
 	return (
 		<div className="EmployerList__Container">
 			<div className="EmployerList__Grid">
@@ -63,7 +71,7 @@ const EmployerList: React.FC = (): React.ReactElement => {
 					))}
 			</div>
 			{visibleItemCount < filteredEmployers.length && (
-				<button className="EmployerList__LoadMore" onClick={(): void => setVisibleItemCount(visibleItemCount + loadMoreCount)}>
+				<button className="EmployerList__LoadMore" onClick={(): void => setListChunksLoaded(listChunksLoaded + 1)}>
 					{format(
 						strings.loadMore,
 						{

--- a/src/web/views/EmployerList/EmployerList.tsx
+++ b/src/web/views/EmployerList/EmployerList.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { useSelector } from "react-redux";
-import { RouteProps } from "react-router-dom";
 
 import { EmployerRecordMetadata } from "../../../common/EmployerRecordMetadata";
 import { format, LocalizedStrings } from "../../../common/LocalizedStrings";
@@ -9,6 +8,7 @@ import { getStrings } from "../../state/ducks/localization/selectors";
 
 import EmployerListItem from "../EmployerListItem/EmployerListItem";
 import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
+import { EmployerRouteContext, EmployerRouteContextData } from "../EmployerRoute/EmployerRouteContext";
 
 import "./EmployerList.scss";
 
@@ -16,17 +16,13 @@ const loadChunkSize: number = 3;
 const loadMoreRowCount: number = 4;
 const loadMoreCount: number = loadChunkSize * loadMoreRowCount;
 
-interface Props extends RouteProps {
-	searchFilter: EmployerListSearchFilter;
-}
-
-const EmployerList: React.FC<Props> = (props: Props): React.ReactElement => {
+const EmployerList: React.FC = (): React.ReactElement => {
 	const strings: LocalizedStrings = useSelector(getStrings);
 	const employersList: EmployerRecordMetadata[] | undefined = useSelector(getEmployersList);
 
-	const [ visibleItemCount, setVisibleItemCount ] = useState(loadMoreCount);
+	const listContext: EmployerRouteContextData = useContext(EmployerRouteContext);
 
-	const { searchFilter } = props;
+	const [ visibleItemCount, setVisibleItemCount ] = useState(loadMoreCount);
 
 	if (!employersList) {
 		return (
@@ -38,7 +34,7 @@ const EmployerList: React.FC<Props> = (props: Props): React.ReactElement => {
 
 	const filteredEmployers: EmployerRecordMetadata[] =
 		employersList
-			.filter((e: EmployerRecordMetadata) => EmployerListSearchFilter.isMatch(searchFilter, e))
+			.filter((e: EmployerRecordMetadata) => EmployerListSearchFilter.isMatch(listContext.searchFilters, e))
 			.sort((a: EmployerRecordMetadata, b: EmployerRecordMetadata) => {
 				const nameMatcher: RegExp = /^(The |A )?(.*)$/i;
 

--- a/src/web/views/EmployerList/EmployerList.tsx
+++ b/src/web/views/EmployerList/EmployerList.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { RouteProps } from "react-router-dom";
 
 import { EmployerRecordMetadata } from "../../../common/EmployerRecordMetadata";
-import { LocalizedStrings } from "../../../common/LocalizedStrings";
+import { format, LocalizedStrings } from "../../../common/LocalizedStrings";
 import { getEmployersList } from "../../state/ducks/employers/selectors";
 import { getStrings } from "../../state/ducks/localization/selectors";
 
@@ -12,6 +12,10 @@ import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSear
 
 import "./EmployerList.scss";
 
+const loadChunkSize: number = 3;
+const loadMoreRowCount: number = 4;
+const loadMoreCount: number = loadChunkSize * loadMoreRowCount;
+
 interface Props extends RouteProps {
 	searchFilter: EmployerListSearchFilter;
 }
@@ -19,6 +23,8 @@ interface Props extends RouteProps {
 const EmployerList: React.FC<Props> = (props: Props): React.ReactElement => {
 	const strings: LocalizedStrings = useSelector(getStrings);
 	const employersList: EmployerRecordMetadata[] | undefined = useSelector(getEmployersList);
+
+	const [ visibleItemCount, setVisibleItemCount ] = useState(loadMoreCount);
 
 	const { searchFilter } = props;
 
@@ -52,11 +58,23 @@ const EmployerList: React.FC<Props> = (props: Props): React.ReactElement => {
 
 	return (
 		<div className="EmployerList__Container">
-			{filteredEmployers.map((e: EmployerRecordMetadata, i: number): JSX.Element => (
-				<div className="EmployerList__Item" key={`${i}-${e.id}`}>
-					<EmployerListItem employerId={e.id} showDetails={true} />
-				</div>
-			))}
+			<div className="EmployerList__Grid">
+				{filteredEmployers.slice(0, visibleItemCount).map(
+					(e: EmployerRecordMetadata, i: number): JSX.Element => (
+						<div className="EmployerList__Item" key={`${i}-${e.id}`}>
+							<EmployerListItem employerId={e.id} showDetails={true} />
+						</div>
+					))}
+			</div>
+			{visibleItemCount < filteredEmployers.length && (
+				<button className="EmployerList__LoadMore" onClick={(): void => setVisibleItemCount(visibleItemCount + loadMoreCount)}>
+					{format(
+						strings.loadMore,
+						{
+							count: Math.min(filteredEmployers.length - visibleItemCount, loadMoreCount),
+						})}
+				</button>
+			)}
 		</div>
 	);
 };

--- a/src/web/views/EmployerList/__snapshots__/EmployerList.test.tsx.snap
+++ b/src/web/views/EmployerList/__snapshots__/EmployerList.test.tsx.snap
@@ -13,14 +13,18 @@ exports[`<EmployerList /> renders list of employers 1`] = `
   className="EmployerList__Container"
 >
   <div
-    className="EmployerList__Item"
+    className="EmployerList__Grid"
   >
-    [component: EmployerListItem employerId=(e2) showDetails=(true) /]
-  </div>
-  <div
-    className="EmployerList__Item"
-  >
-    [component: EmployerListItem employerId=(e3) showDetails=(true) /]
+    <div
+      className="EmployerList__Item"
+    >
+      [component: EmployerListItem employerId=(e2) showDetails=(true) /]
+    </div>
+    <div
+      className="EmployerList__Item"
+    >
+      [component: EmployerListItem employerId=(e3) showDetails=(true) /]
+    </div>
   </div>
 </div>
 `;

--- a/src/web/views/EmployerListPage/EmployerListPage.tsx
+++ b/src/web/views/EmployerListPage/EmployerListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Helmet } from "react-helmet";
 import { useSelector } from "react-redux";
 import { withRouter } from "react-router-dom";
@@ -10,13 +10,10 @@ import { getStrings } from "../../state/ducks/localization/selectors";
 import BackToTopButton from "../BackToTopButton/BackToTopButton";
 import EmployerList from "../EmployerList/EmployerList";
 import EmployerListSearch from "../EmployerListSearch/EmployerListSearch";
-import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
 
 import "./EmployerListPage.scss";
 
 const EmployerListPage: React.FC = (): React.ReactElement => {
-	const [ searchFilters, setSearchFilters ] = useState(new EmployerListSearchFilter());
-
 	const strings: LocalizedStrings = useSelector(getStrings);
 
 	return (
@@ -25,11 +22,11 @@ const EmployerListPage: React.FC = (): React.ReactElement => {
 				<title>{strings.employerList} | {strings.appTitle}</title>
 			</Helmet>
 			<div className="EmployerListPage__Filters">
-				<EmployerListSearch onChange={setSearchFilters} />
+				<EmployerListSearch />
 			</div>
 			<div className="EmployerListPage__Container">
 				<div className="EmployerListPage__Content">
-					<EmployerList searchFilter={searchFilters} />
+					<EmployerList />
 				</div>
 			</div>
 			<BackToTopButton />

--- a/src/web/views/EmployerListPage/__snapshots__/EmployerListPage.test.tsx.snap
+++ b/src/web/views/EmployerListPage/__snapshots__/EmployerListPage.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<EmployerListPage /> renders without exploding 1`] = `
   <div
     className="EmployerListPage__Filters"
   >
-    [component: EmployerListSearch onChange=([Function]) /]
+    [component: EmployerListSearch /]
   </div>
   <div
     className="EmployerListPage__Container"
@@ -15,7 +15,7 @@ exports[`<EmployerListPage /> renders without exploding 1`] = `
     <div
       className="EmployerListPage__Content"
     >
-      [component: EmployerList searchFilter=([object Object]) /]
+      [component: EmployerList /]
     </div>
   </div>
 </main>

--- a/src/web/views/EmployerListSearch/EmployerListSearch.scss
+++ b/src/web/views/EmployerListSearch/EmployerListSearch.scss
@@ -42,6 +42,10 @@ div.EmployerListSearch__InputContainer {
 		flex: 1;
 		padding: $input-buffer;
 		white-space: nowrap;
+
+		input {
+			margin-left: 4px;
+		}
 	}
 
 	.EmployerListSearch__ExpandFilters {

--- a/src/web/views/EmployerListSearch/EmployerListSearch.test.tsx
+++ b/src/web/views/EmployerListSearch/EmployerListSearch.test.tsx
@@ -9,10 +9,9 @@ import { mockComponent, ploc } from "../../../__tests__/TestUtils";
 import { AppState } from "../../state/AppState";
 import configureStore from "../../state/configureStore";
 
-import { EmployerRouteContext, EmployerRouteContextData } from "../EmployerRoute/EmployerRouteContext";
+import { EmployerRouteContext, DefaultContextData } from "../EmployerRoute/EmployerRouteContext";
 
 import EmployerListSearch from "./EmployerListSearch";
-import { EmployerListSearchFilter } from "./EmployerListSearchFilter";
 
 jest.mock(
 	"./EmployerListFilterControl/InternationalTypeFilterControl",
@@ -33,16 +32,11 @@ describe("<EmployerListSearch />", () => {
 	test("renders without exploding", () => {
 		const store: Store<AppState, AnyAction> = createConfigStore();
 
-		const contextValue: EmployerRouteContextData = {
-			searchFilters: new EmployerListSearchFilter(),
-			setSearchFilters: jest.fn(),
-		};
-
 		const testRenderer: ReactTestRenderer =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerRouteContext.Provider value={contextValue}>
+						<EmployerRouteContext.Provider value={DefaultContextData}>
 							<EmployerListSearch />
 						</EmployerRouteContext.Provider>
 					</BrowserRouter>
@@ -55,16 +49,11 @@ describe("<EmployerListSearch />", () => {
 	test("opens 'filters' dropdown", () => {
 		const store: Store<AppState, AnyAction> = createConfigStore();
 
-		const contextValue: EmployerRouteContextData = {
-			searchFilters: new EmployerListSearchFilter(),
-			setSearchFilters: jest.fn(),
-		};
-
 		const testRenderer: ReactTestRenderer =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerRouteContext.Provider value={contextValue}>
+						<EmployerRouteContext.Provider value={DefaultContextData}>
 							<EmployerListSearch />
 						</EmployerRouteContext.Provider>
 					</BrowserRouter>

--- a/src/web/views/EmployerListSearch/EmployerListSearch.test.tsx
+++ b/src/web/views/EmployerListSearch/EmployerListSearch.test.tsx
@@ -9,7 +9,10 @@ import { mockComponent, ploc } from "../../../__tests__/TestUtils";
 import { AppState } from "../../state/AppState";
 import configureStore from "../../state/configureStore";
 
+import { EmployerRouteContext, EmployerRouteContextData } from "../EmployerRoute/EmployerRouteContext";
+
 import EmployerListSearch from "./EmployerListSearch";
+import { EmployerListSearchFilter } from "./EmployerListSearchFilter";
 
 jest.mock(
 	"./EmployerListFilterControl/InternationalTypeFilterControl",
@@ -30,11 +33,18 @@ describe("<EmployerListSearch />", () => {
 	test("renders without exploding", () => {
 		const store: Store<AppState, AnyAction> = createConfigStore();
 
+		const contextValue: EmployerRouteContextData = {
+			searchFilters: new EmployerListSearchFilter(),
+			setSearchFilters: jest.fn(),
+		};
+
 		const testRenderer: ReactTestRenderer =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerListSearch onChange={(): void => { /* Do nothing. */ }} />
+						<EmployerRouteContext.Provider value={contextValue}>
+							<EmployerListSearch />
+						</EmployerRouteContext.Provider>
 					</BrowserRouter>
 				</Provider>,
 			);
@@ -45,11 +55,18 @@ describe("<EmployerListSearch />", () => {
 	test("opens 'filters' dropdown", () => {
 		const store: Store<AppState, AnyAction> = createConfigStore();
 
+		const contextValue: EmployerRouteContextData = {
+			searchFilters: new EmployerListSearchFilter(),
+			setSearchFilters: jest.fn(),
+		};
+
 		const testRenderer: ReactTestRenderer =
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerListSearch onChange={(): void => { /* Do nothing. */ }} />
+						<EmployerRouteContext.Provider value={contextValue}>
+							<EmployerListSearch />
+						</EmployerRouteContext.Provider>
 					</BrowserRouter>
 				</Provider>,
 			);

--- a/src/web/views/EmployerListSearch/EmployerListSearch.tsx
+++ b/src/web/views/EmployerListSearch/EmployerListSearch.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useSelector } from "react-redux";
-import { RouteProps } from "react-router-dom";
 
 import { DesignHelpers } from "../../../common/DesignHelpers";
 import { LocalizedStrings } from "../../../common/LocalizedStrings";
 
 import { getStrings } from "../../state/ducks/localization/selectors";
+
+import { EmployerRouteContext, EmployerRouteContextData } from "../EmployerRoute/EmployerRouteContext";
 
 import EmployeeCountFilterControl from "./EmployerListFilterControl/EmployeeCountFilterControl";
 import InternationalTypeFilterControl from "./EmployerListFilterControl/InternationalTypeFilterControl";
@@ -13,20 +14,17 @@ import { EmployerListSearchFilter } from "./EmployerListSearchFilter";
 
 import "./EmployerListSearch.scss";
 
-interface Props extends RouteProps {
-	onChange: (value: EmployerListSearchFilter) => void;
-}
+const EmployerListSearch: React.FC = (): React.ReactElement => {
+	const listContext: EmployerRouteContextData = useContext(EmployerRouteContext);
 
-const EmployerListSearch: React.FC<Props> = (props: Props): React.ReactElement => {
-	const [ searchFilters, setSearchFilters ] = useState(new EmployerListSearchFilter());
+	const [ searchFilters, setSearchFilters ] = useState(listContext.searchFilters);
 	const [ isFiltersetVisible, setIsFiltersetVisible ] = useState(false);
 
 	const strings: LocalizedStrings = useSelector(getStrings);
-	const { onChange } = props;
 
 	useEffect(
 		(): void => {
-			onChange(searchFilters);
+			listContext.setSearchFilters(searchFilters);
 		},
 		[ searchFilters ]);
 
@@ -43,6 +41,7 @@ const EmployerListSearch: React.FC<Props> = (props: Props): React.ReactElement =
 				<div className="EmployerListSearch__Input">
 					{DesignHelpers.materialIcon("search")}
 					<input
+						defaultValue={searchFilters.text}
 						onInput={onInput}
 						placeholder={strings.search}
 						type="search"

--- a/src/web/views/EmployerListSearch/__snapshots__/EmployerListSearch.test.tsx.snap
+++ b/src/web/views/EmployerListSearch/__snapshots__/EmployerListSearch.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`<EmployerListSearch /> opens 'filters' dropdown 1`] = `
         search
       </i>
       <input
+        defaultValue=""
         onInput={[Function]}
         placeholder="ƨèářçλ"
         type="search"
@@ -57,6 +58,7 @@ exports[`<EmployerListSearch /> renders without exploding 1`] = `
         search
       </i>
       <input
+        defaultValue=""
         onInput={[Function]}
         placeholder="ƨèářçλ"
         type="search"

--- a/src/web/views/EmployerPage/EmployerPage.test.tsx
+++ b/src/web/views/EmployerPage/EmployerPage.test.tsx
@@ -35,16 +35,7 @@ describe("<EmployerPage />", () => {
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerPage
-							history={{} as any}
-							location={{} as any}
-							match={{
-								isExact: true,
-								params: { id: "foo" },
-								path: "/employers",
-								url: "//notused",
-							}}
-						/>
+						<EmployerPage employerId="foo" />
 					</BrowserRouter>
 				</Provider>,
 			).toJSON();
@@ -81,16 +72,7 @@ describe("<EmployerPage />", () => {
 			renderer.create(
 				<Provider store={store}>
 					<BrowserRouter>
-						<EmployerPage
-							history={{} as any}
-							location={{} as any}
-							match={{
-								isExact: true,
-								params: { id: fakeEmployer.id as string },
-								path: "/employers",
-								url: "//notused",
-							}}
-						/>
+						<EmployerPage employerId={fakeEmployer.id || ""} />
 					</BrowserRouter>
 				</Provider>,
 			).toJSON();

--- a/src/web/views/EmployerPage/EmployerPage.tsx
+++ b/src/web/views/EmployerPage/EmployerPage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { useDispatch, useSelector } from "react-redux";
-import { RouteComponentProps } from "react-router-dom";
 
 import { EmployerRecord } from "../../../common/EmployerRecord";
 import { LocalizedStrings } from "../../../common/LocalizedStrings";
@@ -15,17 +14,15 @@ import EmployerPageDetails from "../EmployerPageDetails/EmployerPageDetails";
 
 import "./EmployerPage.scss";
 
-interface Params {
-	id: string;
+interface Props {
+	employerId: string;
 }
-
-type Props = RouteComponentProps<Params>;
 
 const EmployerPage: React.FC<Props> = (props: Props): React.ReactElement => {
 	const strings: LocalizedStrings = useSelector(getStrings);
 	const dispatch: React.Dispatch<any> = useDispatch();
 
-	const employerId: string = props.match.params.id;
+	const employerId: string = props.employerId;
 
 	const hasLoadedEmployers: boolean =
 		useSelector((state: AppState) => !!getEmployersList(state)?.length);

--- a/src/web/views/EmployerRoute/EmployerRoute.tsx
+++ b/src/web/views/EmployerRoute/EmployerRoute.tsx
@@ -5,7 +5,7 @@ import EmployerListPage from "../EmployerListPage/EmployerListPage";
 import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
 import EmployerPage from "../EmployerPage/EmployerPage";
 
-import { EmployerRouteContext } from "./EmployerRouteContext";
+import { EmployerRouteContext, EmployerRouteContextData } from "./EmployerRouteContext";
 
 interface Params {
 	id?: string;
@@ -14,12 +14,20 @@ interface Params {
 type Props = RouteComponentProps<Params>;
 
 const EmployerRoute: React.FC<Props> = (props: Props): React.ReactElement => {
+	const [ listChunksLoaded, setListChunksLoaded ] = useState(1);
 	const [ searchFilters, setSearchFilters ] = useState(new EmployerListSearchFilter());
+
+	const contextData: EmployerRouteContextData = {
+		listChunksLoaded,
+		searchFilters,
+		setListChunksLoaded,
+		setSearchFilters,
+	};
 
 	const employerId: string | undefined = props.match.params.id;
 
 	return (
-		<EmployerRouteContext.Provider value={{ searchFilters, setSearchFilters }}>
+		<EmployerRouteContext.Provider value={contextData}>
 			{employerId ? <EmployerPage employerId={employerId} /> : <EmployerListPage />}
 		</EmployerRouteContext.Provider>
 	);

--- a/src/web/views/EmployerRoute/EmployerRoute.tsx
+++ b/src/web/views/EmployerRoute/EmployerRoute.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { RouteComponentProps } from "react-router-dom";
+
+import EmployerListPage from "../EmployerListPage/EmployerListPage";
+import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
+import EmployerPage from "../EmployerPage/EmployerPage";
+
+import { EmployerRouteContext } from "./EmployerRouteContext";
+
+interface Params {
+	id?: string;
+}
+
+type Props = RouteComponentProps<Params>;
+
+const EmployerRoute: React.FC<Props> = (props: Props): React.ReactElement => {
+	const [ searchFilters, setSearchFilters ] = useState(new EmployerListSearchFilter());
+
+	const employerId: string | undefined = props.match.params.id;
+
+	return (
+		<EmployerRouteContext.Provider value={{ searchFilters, setSearchFilters }}>
+			{employerId ? <EmployerPage employerId={employerId} /> : <EmployerListPage />}
+		</EmployerRouteContext.Provider>
+	);
+};
+
+export default EmployerRoute;

--- a/src/web/views/EmployerRoute/EmployerRouteContext.ts
+++ b/src/web/views/EmployerRoute/EmployerRouteContext.ts
@@ -5,14 +5,27 @@ import React from "react";
 
 import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
 
+type ContextDataSetter<T> = (value: T) => void;
+
+const getDefaultContextDataSetter = <T>(): ContextDataSetter<T> =>
+	(value: T): void => (((): void => { /* Noop. */ }) as any)(value);
+
+export const DefaultContextData: EmployerRouteContextData = {
+	listChunksLoaded: 1,
+	searchFilters: new EmployerListSearchFilter(),
+	setListChunksLoaded: getDefaultContextDataSetter<number>(),
+	setSearchFilters: getDefaultContextDataSetter<EmployerListSearchFilter>(),
+};
+
 export interface EmployerRouteContextData {
+	listChunksLoaded: number;
+
 	searchFilters: EmployerListSearchFilter;
 
-	setSearchFilters: (newFilters: EmployerListSearchFilter) => void;
+	setListChunksLoaded: ContextDataSetter<number>;
+
+	setSearchFilters: ContextDataSetter<EmployerListSearchFilter>;
 }
 
 export const EmployerRouteContext: React.Context<EmployerRouteContextData> =
-	React.createContext({
-		searchFilters: new EmployerListSearchFilter(),
-		setSearchFilters: (newFilters: EmployerListSearchFilter): void => { /* Nothing by default. */ },
-	});
+	React.createContext(DefaultContextData);

--- a/src/web/views/EmployerRoute/EmployerRouteContext.ts
+++ b/src/web/views/EmployerRoute/EmployerRouteContext.ts
@@ -1,0 +1,18 @@
+/* eslint-disable unused-imports/no-unused-vars-ts */
+/* Methods declared in the interface must be used in the context default value, but don't use their arguments. */
+
+import React from "react";
+
+import { EmployerListSearchFilter } from "../EmployerListSearch/EmployerListSearchFilter";
+
+export interface EmployerRouteContextData {
+	searchFilters: EmployerListSearchFilter;
+
+	setSearchFilters: (newFilters: EmployerListSearchFilter) => void;
+}
+
+export const EmployerRouteContext: React.Context<EmployerRouteContextData> =
+	React.createContext({
+		searchFilters: new EmployerListSearchFilter(),
+		setSearchFilters: (newFilters: EmployerListSearchFilter): void => { /* Nothing by default. */ },
+	});

--- a/src/web/views/HomePage/HomePage.scss
+++ b/src/web/views/HomePage/HomePage.scss
@@ -105,7 +105,7 @@ main#home {
 			a {
 				background: $header;
 				border: 1px solid $outline-color;
-				border-radius: 32px;;
+				border-radius: 32px;
 				color: $outline-color;
 				cursor: pointer;
 				display: inline-block;


### PR DESCRIPTION
- Set employer list to only load 12 items
- Allow employer list to load more items on demand
- Set up employer list context to preserve data between page views